### PR TITLE
removed type hinting restrictions on loader args and loader kwargs

### DIFF
--- a/little_cheesemonger/_loader.py
+++ b/little_cheesemonger/_loader.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from importlib import import_module
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from toml import TomlDecodeError
 from toml import load as load_toml
@@ -78,8 +78,8 @@ def import_loader_function(import_path: str) -> Callable:
 def load_configuration(
     directory: Path,
     loader_import_path: Optional[str],
-    loader_args: Tuple[str, ...],
-    loader_kwargs: Dict[str, str],
+    loader_args: Tuple[Any, ...],
+    loader_kwargs: Dict[str, Any],
 ) -> ConfigurationType:
 
     configuration: ConfigurationType = copy.copy(DEFAULT_CONFIGURATION)

--- a/little_cheesemonger/_run.py
+++ b/little_cheesemonger/_run.py
@@ -2,7 +2,7 @@ import logging
 import os
 import subprocess  # nosec
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from little_cheesemonger._errors import LittleCheesemongerError
 from little_cheesemonger._loader import load_configuration
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 def run(
     directory: Path,
     loader_import_path: Optional[str],
-    loader_args: Tuple[str, ...],
-    loader_kwargs: Dict[str, str],
+    loader_args: Tuple[Any, ...],
+    loader_kwargs: Dict[str, Any],
     debug: bool,
 ) -> None:
     """Run build environment setup per configuration."""


### PR DESCRIPTION
* removed type hinting restrictions on loader args and loader kwargs
* when called from python, these are user supplied for a user created function so the user should be in control here
