### PR TITLE
implemented ability to select python version

### DIFF
--- a/little_cheesemonger/__init__.py
+++ b/little_cheesemonger/__init__.py
@@ -1,4 +1,4 @@
 from little_cheesemonger._errors import LittleCheesemongerError  # noqa
 from little_cheesemonger._run import run  # noqa
 
-__version__ = "0.1.0rc0"
+__version__ = "0.1.0rc1"

--- a/little_cheesemonger/__init__.py
+++ b/little_cheesemonger/__init__.py
@@ -1,5 +1,10 @@
+from little_cheesemonger._constants import (  # noqa
+    PYTHON_BINARIES,
+    Architecture,
+    Platform,
+    PythonVersion,
+)
 from little_cheesemonger._errors import LittleCheesemongerError  # noqa
 from little_cheesemonger._run import run  # noqa
-from little_cheesemonger._constants import Architecture, Platform, PythonVersion, PYTHON_BINARIES
 
 __version__ = "0.1.0rc2"

--- a/little_cheesemonger/__init__.py
+++ b/little_cheesemonger/__init__.py
@@ -1,4 +1,5 @@
 from little_cheesemonger._errors import LittleCheesemongerError  # noqa
 from little_cheesemonger._run import run  # noqa
+from little_cheesemonger._constants import Architecture, Platform, PythonVersion, PYTHON_BINARIES
 
 __version__ = "0.1.0rc1"

--- a/little_cheesemonger/__init__.py
+++ b/little_cheesemonger/__init__.py
@@ -2,4 +2,4 @@ from little_cheesemonger._errors import LittleCheesemongerError  # noqa
 from little_cheesemonger._run import run  # noqa
 from little_cheesemonger._constants import Architecture, Platform, PythonVersion, PYTHON_BINARIES
 
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0rc2"

--- a/little_cheesemonger/_constants.py
+++ b/little_cheesemonger/_constants.py
@@ -56,5 +56,6 @@ DEFAULT_CONFIGURATION: ConfigurationType = {
     "environment_variables": None,
     "system_dependencies": None,
     "python_dependencies": None,
+    "python_versions": None,
     "steps": None,
 }

--- a/little_cheesemonger/_run.py
+++ b/little_cheesemonger/_run.py
@@ -77,14 +77,16 @@ def install_python_dependencies(
     all_binaries = get_python_binaries()
 
     if python_versions is None:
-        binaries_paths = list(all_binaries.values()) # NOTE: cast to list for mypy, fix this
+        binaries_paths = list(
+            all_binaries.values()
+        )  # NOTE: cast to list for mypy, fix this
     else:
         try:
             version_keys = [PythonVersion[version] for version in python_versions]
             binaries_paths = [all_binaries[version] for version in version_keys]
         except KeyError as e:
             raise LittleCheesemongerError(
-                f"A Python version from specified versions {versions} is not installed on this image: {e}"
+                f"A Python version from specified versions {python_versions} is not installed on this image: {e}"
             )
 
     for binaries in binaries_paths:

--- a/little_cheesemonger/_run.py
+++ b/little_cheesemonger/_run.py
@@ -4,6 +4,7 @@ import subprocess  # nosec
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from little_cheesemonger._constants import PythonVersion
 from little_cheesemonger._errors import LittleCheesemongerError
 from little_cheesemonger._loader import load_configuration
 from little_cheesemonger._platform import get_python_binaries
@@ -35,7 +36,9 @@ def run(
         install_system_dependencies(configuration["system_dependencies"])
 
     if configuration["python_dependencies"] is not None:
-        install_python_dependencies(configuration["python_dependencies"])
+        install_python_dependencies(
+            configuration["python_dependencies"], configuration["python_versions"]
+        )
 
     if configuration["steps"] is not None:
         execute_steps(configuration["steps"])
@@ -66,10 +69,18 @@ def install_system_dependencies(dependencies: List[str]) -> None:
     run_subprocess(["yum", "install", "-y"] + dependencies)
 
 
-def install_python_dependencies(dependencies: List[str]) -> None:
+def install_python_dependencies(
+    dependencies: List[str], python_versions: Optional[List[str]]
+) -> None:
     """Install Python dependencies."""
 
-    for binaries in get_python_binaries().values():
+    if python_versions is None:
+        binaries_paths = list(get_python_binaries().values())
+    else:
+        version_keys = [PythonVersion[version] for version in python_versions]
+        binaries_paths = [get_python_binaries()[version] for version in version_keys]
+
+    for binaries in binaries_paths:
         run_subprocess([str(binaries / "pip"), "install"] + dependencies)
 
 

--- a/little_cheesemonger/_run.py
+++ b/little_cheesemonger/_run.py
@@ -74,11 +74,18 @@ def install_python_dependencies(
 ) -> None:
     """Install Python dependencies."""
 
+    all_binaries = get_python_binaries()
+
     if python_versions is None:
-        binaries_paths = list(get_python_binaries().values())
+        binaries_paths = list(all_binaries.values()) # NOTE: cast to list for mypy, fix this
     else:
-        version_keys = [PythonVersion[version] for version in python_versions]
-        binaries_paths = [get_python_binaries()[version] for version in version_keys]
+        try:
+            version_keys = [PythonVersion[version] for version in python_versions]
+            binaries_paths = [all_binaries[version] for version in version_keys]
+        except KeyError as e:
+            raise LittleCheesemongerError(
+                f"A Python version from specified versions {versions} is not installed on this image: {e}"
+            )
 
     for binaries in binaries_paths:
         run_subprocess([str(binaries / "pip"), "install"] + dependencies)

--- a/little_cheesemonger/_types.py
+++ b/little_cheesemonger/_types.py
@@ -11,4 +11,5 @@ class ConfigurationType(TypedDict):
     environment_variables: Optional[List[str]]
     system_dependencies: Optional[List[str]]
     python_dependencies: Optional[List[str]]
+    python_versions: Optional[List[str]]
     steps: Optional[List[str]]

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -16,9 +16,13 @@ class Platform(str, Enum):
     platform = PLATFORM
 
 
+class PythonVersion(str, Enum):
+    foo38 = PYTHON_VERSION
+
+
 PYTHON_BINARIES = {
     Architecture.architecture: {
-        Platform.platform: {PYTHON_VERSION: PYTHON_BINARIES_PATH}
+        Platform.platform: {PythonVersion.foo38: PYTHON_BINARIES_PATH}
     }
 }
 
@@ -29,10 +33,12 @@ LOADER_KWARGS = {"foo": "bar"}
 ENVIRONMENT_VARIABLES = ["foo=bar"]
 SYSTEM_DEPENDENCIES = ["foo-1.0.0"]
 PYTHON_DEPENDENCIES = ["foo==1.0.0"]
+PYTHON_VERSIONS = [PYTHON_VERSION]
 STEPS = ["foo"]
 CONFIGURATION = {
     "environment_variables": ENVIRONMENT_VARIABLES,
     "system_dependencies": SYSTEM_DEPENDENCIES,
     "python_dependencies": PYTHON_DEPENDENCIES,
+    "python_versions": PYTHON_VERSIONS,
     "steps": STEPS,
 }

--- a/tests/integration/assets/example_package/pyproject.toml
+++ b/tests/integration/assets/example_package/pyproject.toml
@@ -5,6 +5,12 @@ environment_variables = [
 system_dependencies = [
   "atlas"
 ]
+python_versions = [
+  "cp36-cp36m",
+  "cp36-cp37m",
+  "cp36-cp38",
+  "cp36-cp39"
+]
 python_dependencies = [
   "nyancat==0.1.2"
 ]
@@ -19,6 +25,12 @@ environment_variables = [
 system_dependencies = [
   "atlas"
 ]
+python_versions = [
+  "cp36-cp36m",
+  "cp36-cp37m",
+  "cp36-cp38",
+  "cp36-cp39"
+]
 python_dependencies = [
   "nyancat==0.1.2"
 ]
@@ -32,6 +44,12 @@ environment_variables = [
 ]
 system_dependencies = [
   "atlas"
+]
+python_versions = [
+  "cp36-cp36m",
+  "cp36-cp37m",
+  "cp36-cp38",
+  "cp36-cp39"
 ]
 python_dependencies = [
   "nyancat==0.1.2"

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -278,6 +278,16 @@ def test_install_python_dependencies__python_versions_set__run_subprocess_called
     )
 
 
+def test_install_python_dependencies__python_versions_invalid__raise_LittleCheesemongerError(
+    run_subprocess_mock, get_python_binaries
+):
+
+    with pytest.raises(
+        LittleCheesemongerError, match=r"A Python version from specified versions .*"
+    ):
+        install_python_dependencies(PYTHON_DEPENDENCIES, ["invalid"])
+
+
 def test_install_python_dependencies__python_versions_not_set__run_subprocess_called_with_command(
     run_subprocess_mock, get_python_binaries
 ):

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -25,9 +25,11 @@ from tests.constants import (
     PYTHON_BINARIES,
     PYTHON_DEPENDENCIES,
     PYTHON_VERSION,
+    PYTHON_VERSIONS,
     STEPS,
     SYSTEM_DEPENDENCIES,
 )
+from tests.constants import PythonVersion as PythonVersionTesting
 
 DEBUG = False
 
@@ -70,6 +72,11 @@ def get_python_binaries(mocker):
         "little_cheesemonger._run.get_python_binaries",
         return_value=PYTHON_BINARIES[ARCHITECTURE][PLATFORM],
     )
+
+
+@pytest.fixture(autouse=True)
+def python_versions_enum(mocker):
+    return mocker.patch("little_cheesemonger._run.PythonVersion", PythonVersionTesting)
 
 
 @pytest.fixture
@@ -178,7 +185,9 @@ def test_run__python_dependencies_set_in_configuration__install_python_dependenc
 
     run(DIRECTORY, LOADER_IMPORT_PATH, LOADER_ARGS, LOADER_KWARGS, DEBUG)
 
-    install_python_dependencies_mock.assert_called_once_with(PYTHON_DEPENDENCIES)
+    install_python_dependencies_mock.assert_called_once_with(
+        PYTHON_DEPENDENCIES, PYTHON_VERSIONS
+    )
 
 
 def test_run__python_dependencies_not_set_in_configuration__install_python_dependencies_not_called(
@@ -254,11 +263,26 @@ def test_install_system_dependencies__run_subprocess_called_with_command(
     )
 
 
-def test_install_python_dependencies__run_subprocess_called_with_command(
+def test_install_python_dependencies__python_versions_set__run_subprocess_called_with_command(
     run_subprocess_mock, get_python_binaries
 ):
 
-    install_python_dependencies(PYTHON_DEPENDENCIES)
+    install_python_dependencies(PYTHON_DEPENDENCIES, PYTHON_VERSIONS)
+
+    run_subprocess_mock.assert_called_once_with(
+        [
+            str(PYTHON_BINARIES[ARCHITECTURE][PLATFORM][PYTHON_VERSION] / "pip"),
+            "install",
+        ]
+        + PYTHON_DEPENDENCIES
+    )
+
+
+def test_install_python_dependencies__python_versions_not_set__run_subprocess_called_with_command(
+    run_subprocess_mock, get_python_binaries
+):
+
+    install_python_dependencies(PYTHON_DEPENDENCIES, None)
 
     run_subprocess_mock.assert_called_once_with(
         [


### PR DESCRIPTION
* implemented ability to select python version via configuration, to determine which python version dependencies are installed for. previously system dependencies were installed for all available versions of python, but this resulted in error when testing with wheelhaus service.
* updated assoicated tests