### PR TITLE
Add testing support for 3.9 and 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
         - name: "Check out code"
           uses: "actions/checkout@v2"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  PYTHON_VERSION: "3.8.5"
+  PYTHON_VERSION: "3.10.7"
 
 jobs:
   bandit:
@@ -94,7 +94,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     steps:
         - name: "Check out code"
           uses: "actions/checkout@v2"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
     steps:
         - name: "Check out code"
           uses: "actions/checkout@v2"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9]
     steps:
         - name: "Check out code"
           uses: "actions/checkout@v2"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,6 +1,6 @@
 name: Publish Release
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 on:
   release:
     types: [published]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Removed Support for testing in Python 3.6
 * Added Support for testing in Python 3.9 and 3.10
 * Add Python 3.10 support to the PythonVersion constants and pyproject.toml python_versions
 * Update workflow testing version to python 3.10.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Removed Support for testing in Python 3.6
+* Added Support for testing in Python 3.9 and 3.10
+* Add Python 3.10 support to the PythonVersion constants and pyproject.toml python_versions
+* Update workflow testing version to python 3.10.7
+
 ## [0.2.1] - 2021-10-21
 
 ### Fixed

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 version: '3.4'
 
 # Defaults
+x-build-args-36: &build_args_36
+  IMAGE_TAG: "3.6-buster"
+
 x-build-args-37: &build_args_37
   IMAGE_TAG: "3.7-buster"
 
@@ -37,6 +40,15 @@ services:
     entrypoint: /bin/bash docker/bump_version.sh
 
   # Test & Lint suite
+
+  test-36:
+    <<: *dev
+    build:
+      <<: *dev_build
+      args:
+        IMAGE: python:3.6-buster
+    image: little-cheesemonger-test-36
+    command: docker/run_tests.sh
 
   test-37:
     <<: *dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,17 @@
 version: '3.4'
 
 # Defaults
-
-x-build-args-36: &build_args_36
-  IMAGE_TAG: "3.6-buster"
-
 x-build-args-37: &build_args_37
   IMAGE_TAG: "3.7-buster"
 
 x-build-args-38: &build_args_38
   IMAGE_TAG: "3.8-buster"
+
+x-build-args-39: &build_args_39
+  IMAGE_TAG: "3.9-buster"
+
+x-build-args-310: &build_args_310
+  IMAGE_TAG: "3.10-buster"
 
 x-mount-app-and-user-git-config: &mount-app-and-user-git-config
   volumes:
@@ -35,16 +37,7 @@ services:
     entrypoint: /bin/bash docker/bump_version.sh
 
   # Test & Lint suite
-  
-  test-36:
-    <<: *dev
-    build:
-      <<: *dev_build
-      args:
-        IMAGE: python:3.6-buster
-    image: little-cheesemonger-test-36
-    command: docker/run_tests.sh
-  
+
   test-37:
     <<: *dev
     build:
@@ -54,8 +47,6 @@ services:
     image: little-cheesemonger-test-37
     command: docker/run_tests.sh
   
-  # NOTE: test-38 command includes `--format-code` option that will
-  # apply changes when the lint suite is run
   test-38:
     <<: *dev
     build:
@@ -63,7 +54,29 @@ services:
       args:
         IMAGE: python:3.8-buster
     image: little-cheesemonger-test-38
+    command: docker/run_tests.sh
+  
+  test-39:
+    <<: *dev
+    build:
+      <<: *dev_build
+      args:
+        IMAGE: python:3.9-buster
+    image: little-cheesemonger-test-39
+    command: docker/run_tests.sh
+
+  # NOTE: test-310 command includes `--format-code` option that will
+  # apply changes when the lint suite is run
+  test-310:
+    <<: *dev
+    build:
+      <<: *dev_build
+      args:
+        IMAGE: python:3.10-buster
+    image: little-cheesemonger-test-310
     command: docker/run_tests.sh --format-code
+  
+  
   
   test-integration-manylinux1-default-loader: &test_integration
     build: &test_build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=python:3.8-buster
+ARG IMAGE=python:3.10-buster
 FROM ${IMAGE}
 
 # Set up user for automatic git branch creation

--- a/little_cheesemonger/_constants.py
+++ b/little_cheesemonger/_constants.py
@@ -22,6 +22,7 @@ class PythonVersion(str, Enum):
     CP37_CP37M = "cp37-cp37m"
     CP38_CP38 = "cp38-cp38"
     CP39_CP39 = "cp39-cp39"
+    CP310_CP310 = "cp310-cp310"
 
 
 PYTHON_BINARIES = {
@@ -34,6 +35,7 @@ PYTHON_BINARIES = {
             PythonVersion.CP37_CP37M: Path("/opt/python/cp37-cp37m/bin"),
             PythonVersion.CP38_CP38: Path("/opt/python/cp38-cp38/bin"),
             PythonVersion.CP39_CP39: Path("/opt/python/cp39-cp39/bin"),
+            PythonVersion.CP310_CP310: Path("/opt/python/cp310-cp310/bin"),
         },
         Platform.MANYLINUX2010: {
             PythonVersion.CP35_CP35M: Path("/opt/python/cp35-cp35m/bin"),
@@ -41,6 +43,7 @@ PYTHON_BINARIES = {
             PythonVersion.CP37_CP37M: Path("/opt/python/cp37-cp37m/bin"),
             PythonVersion.CP38_CP38: Path("/opt/python/cp38-cp38/bin"),
             PythonVersion.CP39_CP39: Path("/opt/python/cp39-cp39/bin"),
+            PythonVersion.CP310_CP310: Path("/opt/python/cp310-cp310/bin"),
         },
         Platform.MANYLINUX2014: {
             PythonVersion.CP35_CP35M: Path("/opt/python/cp35-cp35m/bin"),
@@ -48,6 +51,7 @@ PYTHON_BINARIES = {
             PythonVersion.CP37_CP37M: Path("/opt/python/cp37-cp37m/bin"),
             PythonVersion.CP38_CP38: Path("/opt/python/cp38-cp38/bin"),
             PythonVersion.CP39_CP39: Path("/opt/python/cp39-cp39/bin"),
+            PythonVersion.CP310_CP310: Path("/opt/python/cp310-cp310/bin"),
         },
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target_version = ['py38']
+target_version = ['py310']
 exclude = '''
 /(
     venv

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+docker-compose run --rm test-36
 docker-compose run --rm test-37
 docker-compose run --rm test-38
 docker-compose run --rm test-39

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-docker-compose run --rm test-36
 docker-compose run --rm test-37
 docker-compose run --rm test-38
+docker-compose run --rm test-39
+docker-compose run --rm test-310

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 

--- a/tests/integration/assets/example_package/pyproject.toml
+++ b/tests/integration/assets/example_package/pyproject.toml
@@ -9,7 +9,8 @@ python_versions = [
   "cp36-cp36m",
   "cp36-cp37m",
   "cp36-cp38",
-  "cp36-cp39"
+  "cp36-cp39",
+  "cp36-cp310"
 ]
 python_dependencies = [
   "nyancat==0.1.2"
@@ -29,7 +30,8 @@ python_versions = [
   "cp36-cp36m",
   "cp36-cp37m",
   "cp36-cp38",
-  "cp36-cp39"
+  "cp36-cp39",
+  "cp36-cp310"
 ]
 python_dependencies = [
   "nyancat==0.1.2"
@@ -49,7 +51,8 @@ python_versions = [
   "cp36-cp36m",
   "cp36-cp37m",
   "cp36-cp38",
-  "cp36-cp39"
+  "cp36-cp39",
+  "cp36-cp310"
 ]
 python_dependencies = [
   "nyancat==0.1.2"

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -64,4 +64,5 @@ def test_get_python_binaries__return_binaries_for_architecture_and_platform(mock
         PythonVersion.CP37_CP37M: Path("/opt/python/cp37-cp37m/bin"),
         PythonVersion.CP38_CP38: Path("/opt/python/cp38-cp38/bin"),
         PythonVersion.CP39_CP39: Path("/opt/python/cp39-cp39/bin"),
+        PythonVersion.CP310_CP310: Path("/opt/python/cp310-cp310/bin"),
     }


### PR DESCRIPTION
This PR does the following:
- Adds support for testing in Python 3.9 and 3.10
- Adds python 3.10 into pyproject.toml versions, manylinux constants, and workflow runs

Closes https://github.com/wayfair-incubator/little-cheesemonger/issues/86